### PR TITLE
Consistent import format, fixes issues for forked dev

### DIFF
--- a/eosapi/api.py
+++ b/eosapi/api.py
@@ -1,6 +1,6 @@
 import time
 
-from eosapi import HttpClient
+from .http_client import HttpClient
 
 
 class Client(HttpClient):
@@ -17,7 +17,7 @@ class Client(HttpClient):
              mode (str): `irreversible` or `head`.
         """
         mode = 'last_irreversible_block_num' if mode == 'irreversible' \
-            else 'head_block_number'
+            else 'head_block_num'
 
         # convert block id to block number
         if type(start_block) == str:

--- a/eosapi/http_client.py
+++ b/eosapi/http_client.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 
 import certifi
 import urllib3
-from eosapi.exceptions import (
+from .exceptions import (
     EosdNoResponse,
     HttpAPIError,
 )


### PR DESCRIPTION
My current dev setup includes this repo as a git submodule in the root of my python project. I have a non-tracked `__init__.py` file I keep at the root of this repo with the contents:

```
from .eosapi import *
```

By renaming the root dir name of this repo to `eosapi`, I can simultaneously use the API as intended (using the same import structure as a `pip` installed version) and also work on improvements to this repo at the same time, without having to push code and run `pip` every time there's a change. The changes in this PR about import consistency allow this setup to work without errors.

If anyone has suggestions on a better workflow setup, I'd love to know :)

There is also an updated `head_block_num` key, which was simply a bug.